### PR TITLE
jzmq dependency update to 2.2.3-SNAPSHOT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ zyre_perf_local
 zyre_perf_remote
 zyre_selftest
 doit
+jeromq
+target
+.idea
+*.iml

--- a/gen-zyre-jeromq.sh
+++ b/gen-zyre-jeromq.sh
@@ -3,7 +3,7 @@
 echo "Generate ZYRE codes use JeroMQ"
 
 TARGET="jeromq"
-JZMQ_VERSION="1.1.0-SNAPSHOT"
+JZMQ_VERSION="2.2.3-SNAPSHOT"
 JEROMQ_VERSION="0.3.0-SNAPSHOT"
 
 if [ ! -d $TARGET ]; then

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>org.zeromq</groupId>
       <artifactId>jzmq</artifactId>
-      <version>1.1.0-SNAPSHOT</version>
+      <version>2.2.3-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.filemq</groupId>


### PR DESCRIPTION
jzmq dependency update to 2.2.3-SNAPSHOT

Resolve compilation error due to ZThread missing in 1.1.0-SNAPSHOT

Signed-off-by: Robert Gallas gallas.robert@gmail.com
