### PR TITLE
ZreInterface should notify caller about remote peer, not self

### DIFF
--- a/src/main/java/org/zyre/ZreInterface.java
+++ b/src/main/java/org/zyre/ZreInterface.java
@@ -383,7 +383,7 @@ public class ZreInterface
             
             //  Now tell the caller about the peer joined a group
             pipe.sendMore ("JOIN");
-            pipe.sendMore (identity);
+            pipe.sendMore (peer.identity());
             pipe.send (name);
             
             return group;
@@ -396,7 +396,7 @@ public class ZreInterface
             
             //  Now tell the caller about the peer joined a group
             pipe.sendMore ("LEAVE");
-            pipe.sendMore (identity);
+            pipe.sendMore (peer.identity());
             pipe.send (name);
             
             return group;


### PR DESCRIPTION
Learning Zyre/Jyre, and going through the code and noticed this.

It looks like ZreInterface is currently notifying the caller about JOIN/LEAVE events, but passing the local peer's identity. Seems like this should be the remote peer's identity.
